### PR TITLE
chore(ci): rename UpdateMocks job to UpdateDist

### DIFF
--- a/.github/workflows/update-dist.yml
+++ b/.github/workflows/update-dist.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  UpdateMocks:
+  UpdateDist:
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Rename the GitHub Actions job from UpdateMocks to UpdateDist in the
update-dist workflow. This clarifies the job's purpose (updating
distribution artifacts) and aligns the job name with the workflow
filename. Adjusting the job name improves readability and maintainability
of CI configuration.