### PR TITLE
chore(deps): group Dependabot updates and bump package version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    groups:
+      ci:
+        patterns:
+          - "*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-milestone-action",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Pure JS GitHub Action to create a Milestone",
   "keywords": [
     "GitHub",


### PR DESCRIPTION
Add a Dependabot group named "ci" that matches all files so weekly
automation bundles CI-related dependency updates together. This
simplifies PR management and reduces PR noise by grouping similar
updates.

Bump package.json version from 1.0.0 to 2.0.0 to reflect a new
release after changes to dependency management.