### PR TITLE
docs: update README and bump example action tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # create-milestone-action
+
 Create a new milestone or return an existing one. Pure JS action.
 
 The action is written in JavaScript for speed of execution.
@@ -24,7 +25,6 @@ The description of a milestone.
 ### `due_on`
 
 The due date of a milestone. Timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.
-
 
 ## Outputs
 
@@ -55,7 +55,7 @@ The due date of the changed milestone.
 ## Example
 
 ```yaml
-uses: sv-tools/create-milestone-action@v1
+uses: sv-tools/create-milestone-action@v2
 with:
   token: ${{ secrets.GITHUB_TOKEN }}
   title: Next


### PR DESCRIPTION
Update README formatting and documentation to fix minor issues and
reflect the new example tag.

- Add a missing blank line at the top for consistent markdown spacing.
- Remove an extra trailing space under the `due_on` description to clean up
  formatting.
- Bump example usage from sv-tools/create-milestone-action@v1 to @v2 to
  reflect the current released version and guide users to the updated
  action.